### PR TITLE
fix: demo init model by NewModel func

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ e = some(where (p.eft == allow))
 [matchers]
 m = g(r.sub, p.sub) && g2(r.obj, p.obj) && r.act == p.act`
 
-	m := model.Model{}
+	m := model.NewModel()
 
 	m.LoadModelFromText(modelText)
 

--- a/demo/v2/v2_demo.go
+++ b/demo/v2/v2_demo.go
@@ -42,7 +42,7 @@ e = some(where (p.eft == allow))
 [matchers]
 m = g(r.sub, p.sub) && g2(r.obj, p.obj) && r.act == p.act`
 
-	m := model.Model{}
+	m := model.NewModel()
 
 	m.LoadModelFromText(modelText)
 


### PR DESCRIPTION
## What happens

The demo panic.

```
➜  v2 git:(master) go run v2_demo.go
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x78 pc=0x10440d124]

goroutine 1 [running]:
github.com/casbin/casbin/v2/model.Model.GetLogger(...)
        /Users/*/ws/go/pkg/mod/github.com/casbin/casbin/v2@v2.63.0/model/model.go:125
github.com/casbin/casbin/v2/model.Model.AddDef(0x104476bc0?, {0x104424bf1, 0x1}, {0x104424bf1, 0x1}, {0x1400011a150, 0xd})
        /Users/*/ws/go/pkg/mod/github.com/casbin/casbin/v2@v2.63.0/model/model.go:68 +0x164
github.com/casbin/casbin/v2/model.loadAssertion(0x104476bc0?, {0x104497728, 0x140001200a0}, {0x104424bf1, 0x1}, {0x104424bf1, 0x1})
        /Users/*/ws/go/pkg/mod/github.com/casbin/casbin/v2@v2.63.0/model/model.go:54 +0xb4
github.com/casbin/casbin/v2/model.loadSection(0x0?, {0x104497728, 0x140001200a0}, {0x104424bf1, 0x1})
        /Users/*/ws/go/pkg/mod/github.com/casbin/casbin/v2@v2.63.0/model/model.go:105 +0xc0
github.com/casbin/casbin/v2/model.Model.loadModelFromConfig(0x104430810?, {0x104497728, 0x140001200a0})
        /Users/*/ws/go/pkg/mod/github.com/casbin/casbin/v2@v2.63.0/model/model.go:182 +0x80
github.com/casbin/casbin/v2/model.Model.LoadModelFromText(0x140000021a0?, {0x104430810?, 0x14000139f28?})
        /Users/*/ws/go/pkg/mod/github.com/casbin/casbin/v2@v2.63.0/model/model.go:177 +0x54
main.main()
        /Users/*/dev/projects/string-adapter/demo/v2/v2_demo.go:47 +0x34
exit status 2
```

## Why

The `model` should be initialized by `NewModel()` function, other wise the Logger will be nil.

```
# github.com/casbin/casbin/v2@v2.63.0/model/model.go:124

// GetLogger returns the model's logger.
func (model Model) GetLogger() log.Logger {
	return model["logger"]["logger"].logger
}
```